### PR TITLE
feat(sdk): 添加ui表单注解；

### DIFF
--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ui/field/UIComponent.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ui/field/UIComponent.java
@@ -1,12 +1,5 @@
 package org.jetlinks.sdk.server.ui.field;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import org.jetlinks.sdk.server.ui.field.annotation.field.Select;
-import org.springframework.core.annotation.AnnotatedElementUtils;
-
-import java.lang.annotation.Annotation;
-
 public interface UIComponent {
     /**
      * 文本框
@@ -87,6 +80,36 @@ public interface UIComponent {
      * 下拉选择
      */
     String SELECT = "select";
+
+    /**
+     * 数据源配置
+     */
+    String DATA_SOURCE_CONFIG = "dataSourceConfig";
+
+    /**
+     * 数据源支持
+     */
+    String DATA_SOURCE_SUPPORT = "dataSourceSupport";
+
+    /**
+     * 设备
+     */
+    String DEVICE = "device";
+
+    /**
+     * 组织
+     */
+    String ORGANIZATION = "organization";
+
+    /**
+     * 产品
+     */
+    String PRODUCT = "product";
+
+    /**
+     * 用户
+     */
+    String USER = "user";
 
 
 }

--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ui/field/annotation/field/DataSourceConfig.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ui/field/annotation/field/DataSourceConfig.java
@@ -1,0 +1,27 @@
+package org.jetlinks.sdk.server.ui.field.annotation.field;
+
+import org.jetlinks.sdk.server.ui.field.UIComponent;
+import org.jetlinks.sdk.server.ui.field.UIScopeType;
+import org.jetlinks.sdk.server.ui.field.annotation.UIField;
+import org.jetlinks.sdk.server.ui.field.annotation.UIOrder;
+import org.jetlinks.sdk.server.ui.field.annotation.UIScope;
+import org.springframework.core.annotation.AliasFor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@UIField(UIComponent.DATA_SOURCE_CONFIG)
+@UIScope
+@UIOrder
+public @interface DataSourceConfig {
+
+    @AliasFor(annotation = UIScope.class, value = "value")
+    UIScopeType[] scope() default {};
+
+    @AliasFor(annotation = UIOrder.class, value = "value")
+    int order() default 0;
+}

--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ui/field/annotation/field/DataSourceSupport.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ui/field/annotation/field/DataSourceSupport.java
@@ -1,0 +1,27 @@
+package org.jetlinks.sdk.server.ui.field.annotation.field;
+
+import org.jetlinks.sdk.server.ui.field.UIComponent;
+import org.jetlinks.sdk.server.ui.field.UIScopeType;
+import org.jetlinks.sdk.server.ui.field.annotation.UIField;
+import org.jetlinks.sdk.server.ui.field.annotation.UIOrder;
+import org.jetlinks.sdk.server.ui.field.annotation.UIScope;
+import org.springframework.core.annotation.AliasFor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@UIField(UIComponent.DATA_SOURCE_SUPPORT)
+@UIScope
+@UIOrder
+public @interface DataSourceSupport {
+
+    @AliasFor(annotation = UIScope.class, value = "value")
+    UIScopeType[] scope() default {};
+
+    @AliasFor(annotation = UIOrder.class, value = "value")
+    int order() default 0;
+}

--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ui/field/annotation/field/Device.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ui/field/annotation/field/Device.java
@@ -1,0 +1,28 @@
+package org.jetlinks.sdk.server.ui.field.annotation.field;
+
+import org.jetlinks.sdk.server.ui.field.UIComponent;
+import org.jetlinks.sdk.server.ui.field.UIScopeType;
+import org.jetlinks.sdk.server.ui.field.annotation.UIField;
+import org.jetlinks.sdk.server.ui.field.annotation.UIOrder;
+import org.jetlinks.sdk.server.ui.field.annotation.UIScope;
+import org.springframework.core.annotation.AliasFor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@UIField(UIComponent.DEVICE)
+@UIScope
+@UIOrder
+public @interface Device {
+
+    @AliasFor(annotation = UIScope.class, value = "value")
+    UIScopeType[] scope() default {};
+
+    @AliasFor(annotation = UIOrder.class, value = "value")
+    int order() default 0;
+
+}

--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ui/field/annotation/field/Organization.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ui/field/annotation/field/Organization.java
@@ -1,0 +1,29 @@
+package org.jetlinks.sdk.server.ui.field.annotation.field;
+
+import org.jetlinks.sdk.server.ui.field.UIComponent;
+import org.jetlinks.sdk.server.ui.field.UIScopeType;
+import org.jetlinks.sdk.server.ui.field.annotation.UIField;
+import org.jetlinks.sdk.server.ui.field.annotation.UIOrder;
+import org.jetlinks.sdk.server.ui.field.annotation.UIScope;
+import org.springframework.core.annotation.AliasFor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@UIField(UIComponent.ORGANIZATION)
+@UIScope
+@UIOrder
+public @interface Organization {
+
+    @AliasFor(annotation = UIScope.class, value = "value")
+    UIScopeType[] scope() default {};
+
+    @AliasFor(annotation = UIOrder.class, value = "value")
+    int order() default 0;
+
+
+}

--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ui/field/annotation/field/Product.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ui/field/annotation/field/Product.java
@@ -1,0 +1,28 @@
+package org.jetlinks.sdk.server.ui.field.annotation.field;
+
+import org.jetlinks.sdk.server.ui.field.UIComponent;
+import org.jetlinks.sdk.server.ui.field.UIScopeType;
+import org.jetlinks.sdk.server.ui.field.annotation.UIField;
+import org.jetlinks.sdk.server.ui.field.annotation.UIOrder;
+import org.jetlinks.sdk.server.ui.field.annotation.UIScope;
+import org.springframework.core.annotation.AliasFor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@UIField(UIComponent.PRODUCT)
+@UIScope
+@UIOrder
+public @interface Product {
+
+    @AliasFor(annotation = UIScope.class, value = "value")
+    UIScopeType[] scope() default {};
+
+    @AliasFor(annotation = UIOrder.class, value = "value")
+    int order() default 0;
+
+}

--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ui/field/annotation/field/User.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ui/field/annotation/field/User.java
@@ -1,0 +1,28 @@
+package org.jetlinks.sdk.server.ui.field.annotation.field;
+
+import org.jetlinks.sdk.server.ui.field.UIComponent;
+import org.jetlinks.sdk.server.ui.field.UIScopeType;
+import org.jetlinks.sdk.server.ui.field.annotation.UIField;
+import org.jetlinks.sdk.server.ui.field.annotation.UIOrder;
+import org.jetlinks.sdk.server.ui.field.annotation.UIScope;
+import org.springframework.core.annotation.AliasFor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@UIField(UIComponent.USER)
+@UIScope
+@UIOrder
+public @interface User {
+
+    @AliasFor(annotation = UIScope.class, value = "value")
+    UIScopeType[] scope() default {};
+
+    @AliasFor(annotation = UIOrder.class, value = "value")
+    int order() default 0;
+
+}


### PR DESCRIPTION
用于在可视化数据源动态表单支持
现在想的逻辑是，在命令上添加对应的注解，然后在解析命令PropertyMetadata时，添加到expands中，前端获取expands中的标识，渲染对应的组件