### PR TITLE
feat(设备命令): 新增设备接入地址查询命令

### DIFF
--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/device/cmd/GetAccessAddressCommand.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/device/cmd/GetAccessAddressCommand.java
@@ -1,0 +1,33 @@
+package org.jetlinks.sdk.server.device.cmd;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import org.jetlinks.sdk.server.commons.cmd.OperationByIdCommand;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+/**
+ * 获取设备接入网关的接入地址信息.
+ *
+ * @author zhouhao
+ * @since 1.1.1
+ */
+@Schema(title = "获取设备接入网关的接入地址信息")
+public class GetAccessAddressCommand extends OperationByIdCommand<Flux<String>, GetAccessAddressCommand> {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    @Schema(name = PARAMETER_KEY_ID, title = "设备接入网关ID")
+    @NotBlank
+    public String getId() {
+        return super.getId();
+    }
+
+    @Schema(hidden = true)
+    @Override
+    public List<Object> getIdList() {
+        return super.getIdList();
+    }
+}


### PR DESCRIPTION
## 目的

- 新增获取设备接入网关接入地址信息的 SDK 命令定义。

## 核心变动

- `jetlinks-sdk-api`：新增 `GetAccessAddressCommand`，使用 `id` 作为参数，返回 `Flux<String>`。
- 命令继承 `OperationByIdCommand<Flux<String>, GetAccessAddressCommand>`，隐藏 `idList`，保留单 ID 查询语义。

## 测试结果

- 命令：`mvn -pl jetlinks-sdk-api -DskipTests compile`
- 编译结果：237 个 source files 编译通过，0 failed
- 命令：`mvn -pl jetlinks-sdk-api test`
- 单元测试：41 run, 0 failures, 0 errors, 1 skipped
- 覆盖率：当前模块未配置本次命令可用的覆盖率报告，未生成覆盖率数据

## 风险与说明

- 影响范围：仅新增 SDK API 命令类，不改动服务端执行逻辑。
- 未覆盖场景：未新增命令元数据或服务端 handler 测试。
- 已知限制：实际接入地址查询仍需服务端实现对应命令处理。