### PR TITLE
feat(设备命令): 支持设备属性聚合列表达式

### DIFF
--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/device/cmd/QueryPropertyAggCommand.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/device/cmd/QueryPropertyAggCommand.java
@@ -13,13 +13,17 @@ import org.jetlinks.core.metadata.types.StringType;
 import org.jetlinks.sdk.server.commons.AggregationRequest;
 import org.jetlinks.sdk.server.commons.cmd.OperationByIdCommand;
 import org.jetlinks.sdk.server.device.DevicePropertyAggregation;
+import org.jetlinks.sdk.server.utils.AggregationExpressionParser;
+import org.jetlinks.sdk.server.utils.ObjectMappers;
 import org.jetlinks.sdk.server.ui.field.annotation.field.select.DeviceSelector;
 import org.springframework.core.ResolvableType;
+import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 
 import jakarta.validation.constraints.NotBlank;
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -29,7 +33,11 @@ import java.util.function.Function;
  *
  * @author zhangji 2024/1/16
  */
-@Schema(title = "聚合查询设备属性")
+@Schema(
+    title = "聚合查询设备属性",
+    description = "支持按对象数组或表达式字符串传入聚合列。为便于大模型理解与生成参数，推荐优先使用表达式字符串。",
+    example = "{\"id\":\"device-1\",\"columns\":\"avg(temp) as avgTemp, max(humidity) as maxHumidity\",\"query\":{\"interval\":\"1d\",\"from\":\"now-7d\",\"to\":\"now\"}}"
+)
 public class QueryPropertyAggCommand extends OperationByIdCommand<Flux<Map<String, Object>>, QueryPropertyAggCommand> {
 
     private static final long serialVersionUID = 1L;
@@ -52,14 +60,27 @@ public class QueryPropertyAggCommand extends OperationByIdCommand<Flux<Map<Strin
         .forClassWithGenerics(List.class, DevicePropertyAggregation.class)
         .getType();
 
-    @Schema(title = "聚合字段")
+    @Schema(
+        title = "聚合字段",
+        description = "支持2种格式: 1.对象数组; 2.表达式字符串,如: avg(temp) as avgTemp, max(humidity) as maxHumidity。传入字符串时会自动按表达式解析。为便于大模型理解与生成,推荐优先使用表达式字符串。",
+        example = "avg(temp) as avgTemp, max(humidity) as maxHumidity"
+    )
     @NotBlank
     public List<DevicePropertyAggregation> getColumns() {
+        Object columns = readable().get("columns");
+        if (columns instanceof String) {
+            return parseColumns((String) columns);
+        }
         return getOrNull("columns", columnsType);
     }
 
     public QueryPropertyAggCommand withColumns(List<DevicePropertyAggregation> columns) {
         writable().put("columns", columns);
+        return this;
+    }
+
+    public QueryPropertyAggCommand withColumnsExpression(String expression) {
+        writable().put("columns", expression);
         return this;
     }
 
@@ -89,7 +110,7 @@ public class QueryPropertyAggCommand extends OperationByIdCommand<Flux<Map<Strin
             SimplePropertyMetadata.of("id", "Id", StringType.GLOBAL),
             SimplePropertyMetadata.of(
                 "columns",
-                "聚合字段",
+                "聚合字段,支持对象数组或表达式字符串,如: avg(temp) as avgTemp, max(humidity) as maxHumidity",
                 new ArrayType()
                     .elementType(new ObjectType()
                                      .addProperty("property", "属性ID", StringType.GLOBAL)
@@ -115,4 +136,17 @@ public class QueryPropertyAggCommand extends OperationByIdCommand<Flux<Map<Strin
         return CommandMetadataResolver.resolve(QueryPropertyAggCommand.class);
     }
 
+    private List<DevicePropertyAggregation> parseColumns(String columns) {
+        if (!StringUtils.hasText(columns)) {
+            return Collections.emptyList();
+        }
+        String expression = columns.trim();
+        if (expression.startsWith("[")) {
+            return ObjectMappers.parseJsonArray(expression, DevicePropertyAggregation.class);
+        }
+        if (expression.startsWith("{")) {
+            return Collections.singletonList(ObjectMappers.parseJson(expression, DevicePropertyAggregation.class));
+        }
+        return AggregationExpressionParser.parse(expression);
+    }
 }

--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/device/cmd/QueryPropertyAggCommand.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/device/cmd/QueryPropertyAggCommand.java
@@ -147,6 +147,14 @@ public class QueryPropertyAggCommand extends OperationByIdCommand<Flux<Map<Strin
         if (expression.startsWith("{")) {
             return Collections.singletonList(ObjectMappers.parseJson(expression, DevicePropertyAggregation.class));
         }
-        return AggregationExpressionParser.parse(expression);
+        return AggregationExpressionParser.parse(expression, (agg, property, alias) -> {
+            DevicePropertyAggregation aggregation = new DevicePropertyAggregation();
+            aggregation.setAgg(agg);
+            aggregation.setProperty(property);
+            if (StringUtils.hasText(alias)) {
+                aggregation.setAlias(alias);
+            }
+            return aggregation;
+        });
     }
 }

--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/utils/AggregationExpressionParser.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/utils/AggregationExpressionParser.java
@@ -1,12 +1,12 @@
 package org.jetlinks.sdk.server.utils;
 
-import org.jetlinks.sdk.server.device.DevicePropertyAggregation;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * 聚合查询表达式解析器.
@@ -33,19 +33,21 @@ public final class AggregationExpressionParser {
 
     }
 
-    public static List<DevicePropertyAggregation> parse(String expression) {
+    public static <T> List<T> parse(String expression, AggregationMapper<T> mapper) {
+        Objects.requireNonNull(mapper, "aggregation mapper can not be null");
         if (!StringUtils.hasText(expression)) {
             return Collections.emptyList();
         }
         List<String> expressions = split(expression);
-        List<DevicePropertyAggregation> aggregations = new ArrayList<>(expressions.size());
+        List<T> aggregations = new ArrayList<>(expressions.size());
         for (String item : expressions) {
-            aggregations.add(parseColumn(item));
+            aggregations.add(parseColumn(item, mapper));
         }
         return aggregations;
     }
 
-    public static DevicePropertyAggregation parseColumn(String expression) {
+    public static <T> T parseColumn(String expression, AggregationMapper<T> mapper) {
+        Objects.requireNonNull(mapper, "aggregation mapper can not be null");
         if (!StringUtils.hasText(expression)) {
             throw new IllegalArgumentException("aggregation expression can not be blank");
         }
@@ -62,13 +64,7 @@ public final class AggregationExpressionParser {
         }
         String alias = normalizeAlias(normalized.substring(end + 1).trim());
 
-        DevicePropertyAggregation aggregation = new DevicePropertyAggregation();
-        aggregation.setAgg(agg.toLowerCase(Locale.ROOT));
-        aggregation.setProperty(property);
-        if (StringUtils.hasText(alias)) {
-            aggregation.setAlias(alias);
-        }
-        return aggregation;
+        return mapper.apply(agg.toLowerCase(Locale.ROOT), property, alias);
     }
 
     static List<String> split(String expression) {
@@ -193,5 +189,11 @@ public final class AggregationExpressionParser {
             return value.substring(1, value.length() - 1);
         }
         return value;
+    }
+
+    @FunctionalInterface
+    public interface AggregationMapper<T> {
+
+        T apply(String agg, String property, String alias);
     }
 }

--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/utils/AggregationExpressionParser.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/utils/AggregationExpressionParser.java
@@ -1,0 +1,197 @@
+package org.jetlinks.sdk.server.utils;
+
+import org.jetlinks.sdk.server.device.DevicePropertyAggregation;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * 聚合查询表达式解析器.
+ * <pre>
+ *     avg(temp) as avgTemp
+ *     max(properties.humidity) maxHumidity
+ *     count(this.properties['alarm']) -> alarmCount
+ * </pre>
+ *
+ * @author zhouhao
+ * @since 1.1.1
+ */
+public final class AggregationExpressionParser {
+
+    private static final String THIS_PROPERTIES_PREFIX = "this.properties.";
+
+    private static final String PROPERTIES_PREFIX = "properties.";
+
+    private static final String THIS_PROPERTIES_BRACKET_PREFIX = "this.properties[";
+
+    private static final String PROPERTIES_BRACKET_PREFIX = "properties[";
+
+    private AggregationExpressionParser() {
+
+    }
+
+    public static List<DevicePropertyAggregation> parse(String expression) {
+        if (!StringUtils.hasText(expression)) {
+            return Collections.emptyList();
+        }
+        List<String> expressions = split(expression);
+        List<DevicePropertyAggregation> aggregations = new ArrayList<>(expressions.size());
+        for (String item : expressions) {
+            aggregations.add(parseColumn(item));
+        }
+        return aggregations;
+    }
+
+    public static DevicePropertyAggregation parseColumn(String expression) {
+        if (!StringUtils.hasText(expression)) {
+            throw new IllegalArgumentException("aggregation expression can not be blank");
+        }
+        String normalized = expression.trim();
+        int start = normalized.indexOf('(');
+        if (start <= 0) {
+            throw new IllegalArgumentException("invalid aggregation expression: " + expression);
+        }
+        int end = findClosingParenthesis(normalized, start);
+        String agg = normalized.substring(0, start).trim();
+        String property = normalizeProperty(normalized.substring(start + 1, end));
+        if (!StringUtils.hasText(agg) || !StringUtils.hasText(property)) {
+            throw new IllegalArgumentException("invalid aggregation expression: " + expression);
+        }
+        String alias = normalizeAlias(normalized.substring(end + 1).trim());
+
+        DevicePropertyAggregation aggregation = new DevicePropertyAggregation();
+        aggregation.setAgg(agg.toLowerCase(Locale.ROOT));
+        aggregation.setProperty(property);
+        if (StringUtils.hasText(alias)) {
+            aggregation.setAlias(alias);
+        }
+        return aggregation;
+    }
+
+    static List<String> split(String expression) {
+        List<String> expressions = new ArrayList<>();
+        int depth = 0;
+        int start = 0;
+        char inQuote = 0;
+        for (int i = 0, len = expression.length(); i < len; i++) {
+            char ch = expression.charAt(i);
+            if (inQuote != 0) {
+                if (ch == inQuote && !isEscaped(expression, i)) {
+                    inQuote = 0;
+                }
+                continue;
+            }
+            if (ch == '\'' || ch == '"' || ch == '`') {
+                inQuote = ch;
+                continue;
+            }
+            if (ch == '(') {
+                depth++;
+                continue;
+            }
+            if (ch == ')') {
+                depth--;
+                continue;
+            }
+            if (depth == 0 && isSeparator(ch)) {
+                addExpression(expressions, expression.substring(start, i));
+                start = i + 1;
+            }
+        }
+        addExpression(expressions, expression.substring(start));
+        return expressions;
+    }
+
+    private static void addExpression(List<String> expressions, String expression) {
+        if (StringUtils.hasText(expression)) {
+            expressions.add(expression.trim());
+        }
+    }
+
+    private static boolean isSeparator(char ch) {
+        return ch == ',' || ch == ';' || ch == '\n' || ch == '\r';
+    }
+
+    private static int findClosingParenthesis(String expression, int start) {
+        int depth = 0;
+        char inQuote = 0;
+        for (int i = start, len = expression.length(); i < len; i++) {
+            char ch = expression.charAt(i);
+            if (inQuote != 0) {
+                if (ch == inQuote && !isEscaped(expression, i)) {
+                    inQuote = 0;
+                }
+                continue;
+            }
+            if (ch == '\'' || ch == '"' || ch == '`') {
+                inQuote = ch;
+                continue;
+            }
+            if (ch == '(') {
+                depth++;
+                continue;
+            }
+            if (ch == ')') {
+                depth--;
+                if (depth == 0) {
+                    return i;
+                }
+            }
+        }
+        throw new IllegalArgumentException("invalid aggregation expression: " + expression);
+    }
+
+    private static boolean isEscaped(String expression, int index) {
+        return index > 0 && expression.charAt(index - 1) == '\\';
+    }
+
+    private static String normalizeAlias(String alias) {
+        if (!StringUtils.hasText(alias)) {
+            return null;
+        }
+        String normalized = alias.trim();
+        String lower = normalized.toLowerCase(Locale.ROOT);
+        if (lower.startsWith("as ") || lower.startsWith("as\t")) {
+            normalized = normalized.substring(2).trim();
+        } else if (normalized.startsWith("->") || normalized.startsWith("=>")) {
+            normalized = normalized.substring(2).trim();
+        } else if (normalized.startsWith(":")) {
+            normalized = normalized.substring(1).trim();
+        }
+        return stripQuote(normalized);
+    }
+
+    private static String normalizeProperty(String property) {
+        String normalized = stripQuote(property.trim());
+        if (normalized.startsWith(THIS_PROPERTIES_PREFIX)) {
+            return normalized.substring(THIS_PROPERTIES_PREFIX.length());
+        }
+        if (normalized.startsWith(PROPERTIES_PREFIX)) {
+            return normalized.substring(PROPERTIES_PREFIX.length());
+        }
+        if (normalized.startsWith(THIS_PROPERTIES_BRACKET_PREFIX) && normalized.endsWith("]")) {
+            return stripQuote(normalized.substring(THIS_PROPERTIES_BRACKET_PREFIX.length(), normalized.length() - 1).trim());
+        }
+        if (normalized.startsWith(PROPERTIES_BRACKET_PREFIX) && normalized.endsWith("]")) {
+            return stripQuote(normalized.substring(PROPERTIES_BRACKET_PREFIX.length(), normalized.length() - 1).trim());
+        }
+        return normalized;
+    }
+
+    private static String stripQuote(String value) {
+        if (!StringUtils.hasText(value) || value.length() < 2) {
+            return value;
+        }
+        char first = value.charAt(0);
+        char last = value.charAt(value.length() - 1);
+        if ((first == '"' && last == '"')
+            || (first == '\'' && last == '\'')
+            || (first == '`' && last == '`')) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+}

--- a/jetlinks-sdk-api/src/test/java/org/jetlinks/sdk/server/device/cmd/QueryPropertyAggCommandTest.java
+++ b/jetlinks-sdk-api/src/test/java/org/jetlinks/sdk/server/device/cmd/QueryPropertyAggCommandTest.java
@@ -1,0 +1,40 @@
+package org.jetlinks.sdk.server.device.cmd;
+
+import org.jetlinks.sdk.server.device.DevicePropertyAggregation;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class QueryPropertyAggCommandTest {
+
+    @Test
+    void testGetColumnsFromExpression() {
+        QueryPropertyAggCommand command = new QueryPropertyAggCommand()
+            .withColumnsExpression("avg(temp) as avgTemp,max(properties.humidity) as maxHumidity");
+
+        List<DevicePropertyAggregation> columns = command.getColumns();
+
+        assertEquals(2, columns.size());
+        assertEquals("avg", columns.get(0).getAgg());
+        assertEquals("temp", columns.get(0).getProperty());
+        assertEquals("avgTemp", columns.get(0).getAlias());
+        assertEquals("max", columns.get(1).getAgg());
+        assertEquals("humidity", columns.get(1).getProperty());
+        assertEquals("maxHumidity", columns.get(1).getAlias());
+    }
+
+    @Test
+    void testGetColumnsFromJsonString() {
+        QueryPropertyAggCommand command = new QueryPropertyAggCommand()
+            .with("columns", "[{\"property\":\"temp\",\"alias\":\"avgTemp\",\"agg\":\"avg\"}]");
+
+        List<DevicePropertyAggregation> columns = command.getColumns();
+
+        assertEquals(1, columns.size());
+        assertEquals("temp", columns.get(0).getProperty());
+        assertEquals("avgTemp", columns.get(0).getAlias());
+        assertEquals("avg", columns.get(0).getAgg());
+    }
+}

--- a/jetlinks-sdk-api/src/test/java/org/jetlinks/sdk/server/utils/AggregationExpressionParserTest.java
+++ b/jetlinks-sdk-api/src/test/java/org/jetlinks/sdk/server/utils/AggregationExpressionParserTest.java
@@ -1,0 +1,44 @@
+package org.jetlinks.sdk.server.utils;
+
+import org.jetlinks.sdk.server.device.DevicePropertyAggregation;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class AggregationExpressionParserTest {
+
+    @Test
+    void testParseExpressions() {
+        List<DevicePropertyAggregation> aggregations = AggregationExpressionParser.parse("""
+            avg(temp) as avgTemp,
+            max(properties.humidity) maxHumidity;
+            count(this.properties['alarm']) -> alarmCount
+            """);
+
+        assertEquals(3, aggregations.size());
+
+        assertEquals("avg", aggregations.get(0).getAgg());
+        assertEquals("temp", aggregations.get(0).getProperty());
+        assertEquals("avgTemp", aggregations.get(0).getAlias());
+
+        assertEquals("max", aggregations.get(1).getAgg());
+        assertEquals("humidity", aggregations.get(1).getProperty());
+        assertEquals("maxHumidity", aggregations.get(1).getAlias());
+
+        assertEquals("count", aggregations.get(2).getAgg());
+        assertEquals("alarm", aggregations.get(2).getProperty());
+        assertEquals("alarmCount", aggregations.get(2).getAlias());
+    }
+
+    @Test
+    void testParseExpressionWithoutAlias() {
+        DevicePropertyAggregation aggregation = AggregationExpressionParser.parseColumn("SUM(`temp`)");
+
+        assertEquals("sum", aggregation.getAgg());
+        assertEquals("temp", aggregation.getProperty());
+        assertNull(aggregation.getAlias());
+    }
+}

--- a/jetlinks-sdk-api/src/test/java/org/jetlinks/sdk/server/utils/AggregationExpressionParserTest.java
+++ b/jetlinks-sdk-api/src/test/java/org/jetlinks/sdk/server/utils/AggregationExpressionParserTest.java
@@ -4,19 +4,31 @@ import org.jetlinks.sdk.server.device.DevicePropertyAggregation;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 class AggregationExpressionParserTest {
 
+    private static DevicePropertyAggregation createAggregation(String agg, String property, String alias) {
+        DevicePropertyAggregation aggregation = new DevicePropertyAggregation();
+        aggregation.setAgg(agg);
+        aggregation.setProperty(property);
+        aggregation.setAlias(alias);
+        return aggregation;
+    }
+
     @Test
     void testParseExpressions() {
-        List<DevicePropertyAggregation> aggregations = AggregationExpressionParser.parse("""
-            avg(temp) as avgTemp,
-            max(properties.humidity) maxHumidity;
-            count(this.properties['alarm']) -> alarmCount
-            """);
+        List<DevicePropertyAggregation> aggregations = AggregationExpressionParser.parse(
+            """
+                avg(temp) as avgTemp,
+                max(properties.humidity) maxHumidity;
+                count(this.properties['alarm']) -> alarmCount
+                """,
+            AggregationExpressionParserTest::createAggregation
+        );
 
         assertEquals(3, aggregations.size());
 
@@ -35,10 +47,29 @@ class AggregationExpressionParserTest {
 
     @Test
     void testParseExpressionWithoutAlias() {
-        DevicePropertyAggregation aggregation = AggregationExpressionParser.parseColumn("SUM(`temp`)");
+        DevicePropertyAggregation aggregation = AggregationExpressionParser.parseColumn(
+            "SUM(`temp`)",
+            AggregationExpressionParserTest::createAggregation
+        );
 
         assertEquals("sum", aggregation.getAgg());
         assertEquals("temp", aggregation.getProperty());
         assertNull(aggregation.getAlias());
+    }
+
+    @Test
+    void testParseExpressionByMapper() {
+        Map<String, String> aggregation = AggregationExpressionParser.parseColumn(
+            "SUM(`temp`) as totalTemp",
+            (agg, property, alias) -> Map.of(
+                "agg", agg,
+                "property", property,
+                "alias", alias
+            )
+        );
+
+        assertEquals("sum", aggregation.get("agg"));
+        assertEquals("temp", aggregation.get("property"));
+        assertEquals("totalTemp", aggregation.get("alias"));
     }
 }


### PR DESCRIPTION
## 目的

- 为设备属性聚合查询增加更适合大模型理解和生成的表达式输入方式
- 进一步通用化聚合表达式解析器，避免结果模型与 `DevicePropertyAggregation` 强耦合

## 核心变动

- `jetlinks-sdk-api`：新增 `AggregationExpressionParser`，将如 `avg(temp) as avgTemp` 这类表达式解析为聚合函数、属性和别名信息
- `jetlinks-sdk-api`：将 `AggregationExpressionParser` 调整为通过 `AggregationMapper<T>` 回调构造结果，支持不同结果类型复用
- `jetlinks-sdk-api`：优化 `QueryPropertyAggCommand#getColumns()`，当 `columns` 为字符串时，支持按表达式或 JSON 字符串自动解析；命令侧通过 mapper 构造 `DevicePropertyAggregation`
- `jetlinks-sdk-api`：优化 `QueryPropertyAggCommand` 的 Swagger/OpenAPI 说明和示例，提示大模型优先使用表达式字符串传参
- `jetlinks-sdk-api`：补充聚合表达式解析与命令解析相关单元测试

## 测试结果

- 命令：`mvn -pl jetlinks-sdk-api -am test -Dtest=AggregationExpressionParserTest,QueryPropertyAggCommandTest,ConverterUtilsTest -Dsurefire.failIfNoSpecifiedTests=false`
- 单元测试：7 passed, 0 failed, 0 skipped
- 覆盖率：仓库当前未发现 Jacoco/覆盖率插件配置，未产出覆盖率报表；以 `AggregationExpressionParserTest`、`QueryPropertyAggCommandTest`、`ConverterUtilsTest` 的定向验证作为替代证据

## 风险与说明

- 影响范围：`jetlinks-sdk-api` 中设备属性聚合查询命令及相关解析工具
- 未覆盖场景：更复杂或异常格式的聚合表达式组合仍主要依赖现有解析规则
- 已知限制：当前属性名归一化逻辑仍以内置 `properties.*` / `this.properties[*]` 规则为主，尚未进一步抽象为可插拔策略
