### PR TITLE
feat: 增加目标检测ROI标注结构

### DIFF
--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ai/cv/ImageData.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ai/cv/ImageData.java
@@ -32,6 +32,7 @@ public class ImageData implements FileData, Externalizable {
     @Schema(description = "图片数据")
     private ByteBuf data;
 
+    @Deprecated
     @Schema(description = "图片类型")
     private Type type;
 
@@ -128,6 +129,7 @@ public class ImageData implements FileData, Externalizable {
         ReferenceCountUtil.safeRelease(data);
     }
 
+    @Deprecated
     @Getter
     @AllArgsConstructor
     public enum Type {

--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ai/cv/ObjectDetectionResult.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ai/cv/ObjectDetectionResult.java
@@ -95,6 +95,20 @@ public class ObjectDetectionResult extends AiCommandResult<ObjectDetectionResult
         @Schema(title = "其他信息")
         private Map<String, Object> others;
 
+        public void addAnnotation(String key, Object value) {
+            if (annotations == null) {
+                annotations = Maps.newHashMap();
+            }
+            annotations.put(key, value);
+        }
+
+        public void addOther(String key, Object value) {
+            if (others == null) {
+                others = Maps.newHashMap();
+            }
+            others.put(key, value);
+        }
+
         @Override
         public void writeExternal(ObjectOutput out) throws IOException {
             SerializeUtils.writeNullableUTF(objectId, out);

--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ai/cv/data/KeyPoint.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ai/cv/data/KeyPoint.java
@@ -24,13 +24,13 @@ public class KeyPoint implements Externalizable {
     private String name;
 
     @Schema(title = "x轴坐标")
-    private float coordinateX;
+    private float x;
 
     @Schema(title = "y轴坐标")
-    private float coordinateY;
+    private float y;
 
     @Schema(title = "z轴坐标")
-    private float coordinateZ;
+    private float z;
 
     @Schema(title = "置信度")
     private float score;
@@ -63,9 +63,9 @@ public class KeyPoint implements Externalizable {
         KeyPoint point = new KeyPoint();
         point.setIndex(index);
         point.setName(name);
-        point.setCoordinateX(coordinateX);
-        point.setCoordinateY(coordinateY);
-        point.setCoordinateZ(coordinateZ);
+        point.setX(coordinateX);
+        point.setY(coordinateY);
+        point.setZ(coordinateZ);
         point.setScore(score);
         point.setVisibility(visibility);
         return point;
@@ -75,9 +75,9 @@ public class KeyPoint implements Externalizable {
     public void writeExternal(ObjectOutput out) throws IOException {
         out.writeInt(index);
         SerializeUtils.writeNullableUTF(name, out);
-        out.writeFloat(coordinateX);
-        out.writeFloat(coordinateY);
-        out.writeFloat(coordinateZ);
+        out.writeFloat(x);
+        out.writeFloat(y);
+        out.writeFloat(z);
         out.writeFloat(score);
         SerializeUtils.writeNullableUTF(visibility == null ? null : visibility.name(), out);
         SerializeUtils.writeKeyValue(others, out);
@@ -87,9 +87,9 @@ public class KeyPoint implements Externalizable {
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
         index = in.readInt();
         name = SerializeUtils.readNullableUTF(in);
-        coordinateX = in.readFloat();
-        coordinateY = in.readFloat();
-        coordinateZ = in.readFloat();
+        x = in.readFloat();
+        y = in.readFloat();
+        z = in.readFloat();
         score = in.readFloat();
         String visibility = SerializeUtils.readNullableUTF(in);
         if (visibility != null) {

--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ai/cv/data/RoiObject.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ai/cv/data/RoiObject.java
@@ -1,0 +1,119 @@
+package org.jetlinks.sdk.server.ai.cv.data;
+
+import com.google.common.collect.Maps;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.commons.collections4.CollectionUtils;
+import org.jetlinks.core.utils.SerializeUtils;
+
+import javax.annotation.Nullable;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 目标检测结果关联的 ROI 标注信息，用于声明识别数据命中的任务区域或线段。
+ */
+@Getter
+@Setter
+public class RoiObject implements Externalizable {
+
+    public static final String ANNOTATIONS_KEY = "roi";
+
+    @Schema(title = "ROI信息")
+    private List<Roi> roi;
+
+    public void add(Roi... roi) {
+        if (this.roi == null) {
+            this.roi = new ArrayList<>();
+        }
+        this.roi.addAll(List.of(roi));
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        if (CollectionUtils.isEmpty(roi)) {
+            out.writeInt(0);
+        } else {
+            out.writeInt(roi.size());
+            for (Roi item : roi) {
+                item.writeExternal(out);
+            }
+        }
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        int size = in.readInt();
+        if (size > 0) {
+            roi = new ArrayList<>(size);
+            for (int i = 0; i < size; i++) {
+                Roi item = new Roi();
+                item.readExternal(in);
+                roi.add(item);
+            }
+        } else {
+            roi = new ArrayList<>(0);
+        }
+    }
+
+    /**
+     * 单个 ROI 匹配结果。
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Roi implements Externalizable {
+
+        @Schema(title = "ROI坐标", description = "线段或区域坐标,格式如:x1,y1;x2,y2...")
+        private String roi;
+
+        @Schema(title = "ROI类型", description = "line为线段,area为区域")
+        private String type;
+
+        //线段的进入：延线段指向（起始点->终点）顺时针旋转 90 度指向的为右侧，从左到右为进入线段
+        @Nullable
+        @Schema(title = "是否进入", description = "true为进入")
+        private Boolean enter;
+
+        @Schema(title = "其他信息")
+        private Map<String, Object> others;
+
+        public static Roi line(String roi, boolean enter, Map<String, Object> others) {
+            return new Roi(roi, "line", enter, others);
+        }
+
+        public static Roi area(String roi, Map<String, Object> others) {
+            return new Roi(roi, "area", null, others);
+        }
+
+        @Override
+        public void writeExternal(ObjectOutput out) throws IOException {
+            SerializeUtils.writeNullableUTF(roi, out);
+            SerializeUtils.writeNullableUTF(type, out);
+            out.writeBoolean(enter != null);
+            if (enter != null) {
+                out.writeBoolean(enter);
+            }
+            SerializeUtils.writeKeyValue(others, out);
+        }
+
+        @Override
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+            roi = SerializeUtils.readNullableUTF(in);
+            type = SerializeUtils.readNullableUTF(in);
+            if (in.readBoolean()) {
+                enter = in.readBoolean();
+            }
+            others = SerializeUtils.readMap(in, Maps::newHashMapWithExpectedSize);
+        }
+    }
+}

--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ai/cv/data/RoiObject.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ai/cv/data/RoiObject.java
@@ -26,6 +26,8 @@ import java.util.Map;
 public class RoiObject implements Externalizable {
 
     public static final String ANNOTATIONS_KEY = "roi";
+    public static final String TYPE_LINE = "line";
+    public static final String TYPE_AREA = "area";
 
     @Schema(title = "ROI信息")
     private List<Roi> roi;
@@ -73,13 +75,13 @@ public class RoiObject implements Externalizable {
     @AllArgsConstructor
     public static class Roi implements Externalizable {
 
-        @Schema(title = "ROI坐标", description = "线段或区域坐标,格式如:x1,y1;x2,y2...")
-        private String roi;
+        @Schema(title = "ROI坐标点")
+        private List<Point> points;
 
         @Schema(title = "ROI类型", description = "line为线段,area为区域")
         private String type;
 
-        //线段的进入：延线段指向（起始点->终点）顺时针旋转 90 度指向的为右侧，从左到右为进入线段
+        // 线段进入方向由起点到终点顺时针旋转90度后的右侧决定。
         @Nullable
         @Schema(title = "是否进入", description = "true为进入")
         private Boolean enter;
@@ -87,17 +89,32 @@ public class RoiObject implements Externalizable {
         @Schema(title = "其他信息")
         private Map<String, Object> others;
 
-        public static Roi line(String roi, boolean enter, Map<String, Object> others) {
-            return new Roi(roi, "line", enter, others);
+        public static Roi line(List<Point> points, boolean enter, Map<String, Object> others) {
+            return new Roi(points, TYPE_LINE, enter, others);
         }
 
-        public static Roi area(String roi, Map<String, Object> others) {
-            return new Roi(roi, "area", null, others);
+        public static Roi area(List<Point> points, Map<String, Object> others) {
+            return new Roi(points, TYPE_AREA, null, others);
+        }
+
+        public boolean isLine() {
+            return TYPE_LINE.equals(type);
+        }
+
+        public boolean isArea() {
+            return TYPE_AREA.equals(type);
         }
 
         @Override
         public void writeExternal(ObjectOutput out) throws IOException {
-            SerializeUtils.writeNullableUTF(roi, out);
+            if (CollectionUtils.isEmpty(points)) {
+                out.writeInt(0);
+            } else {
+                out.writeInt(points.size());
+                for (Point point : points) {
+                    point.writeExternal(out);
+                }
+            }
             SerializeUtils.writeNullableUTF(type, out);
             out.writeBoolean(enter != null);
             if (enter != null) {
@@ -108,12 +125,54 @@ public class RoiObject implements Externalizable {
 
         @Override
         public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-            roi = SerializeUtils.readNullableUTF(in);
+            int size = in.readInt();
+            if (size > 0) {
+                points = new ArrayList<>(size);
+                for (int i = 0; i < size; i++) {
+                    Point point = new Point();
+                    point.readExternal(in);
+                    points.add(point);
+                }
+            } else {
+                points = new ArrayList<>(0);
+            }
             type = SerializeUtils.readNullableUTF(in);
             if (in.readBoolean()) {
                 enter = in.readBoolean();
             }
             others = SerializeUtils.readMap(in, Maps::newHashMapWithExpectedSize);
+        }
+    }
+
+    /**
+     * ROI坐标点。
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Point implements Externalizable {
+
+        @Schema(title = "x轴坐标")
+        private float coordinateX;
+
+        @Schema(title = "y轴坐标")
+        private float coordinateY;
+
+        public static Point of(float coordinateX, float coordinateY) {
+            return new Point(coordinateX, coordinateY);
+        }
+
+        @Override
+        public void writeExternal(ObjectOutput out) throws IOException {
+            out.writeFloat(coordinateX);
+            out.writeFloat(coordinateY);
+        }
+
+        @Override
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+            coordinateX = in.readFloat();
+            coordinateY = in.readFloat();
         }
     }
 }

--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ai/cv/data/RoiObject.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ai/cv/data/RoiObject.java
@@ -193,7 +193,7 @@ public class RoiObject implements Externalizable {
             }
             StringBuilder builder = new StringBuilder();
             for (Point point : points) {
-                if (builder.length() > 0) {
+                if (!builder.isEmpty()) {
                     builder.append(';');
                 }
                 builder

--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ai/cv/data/RoiObject.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ai/cv/data/RoiObject.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetlinks.core.utils.SerializeUtils;
 
 import javax.annotation.Nullable;
@@ -81,13 +82,17 @@ public class RoiObject implements Externalizable {
         @Schema(title = "ROI类型", description = "line为线段,area为区域")
         private String type;
 
-        // 线段进入方向由起点到终点顺时针旋转90度后的右侧决定。
+        // 线段方向由起点到终点顺时针旋转90度后的方向为入口。
         @Nullable
         @Schema(title = "是否进入", description = "true为进入")
         private Boolean enter;
 
         @Schema(title = "其他信息")
         private Map<String, Object> others;
+
+        public static Roi of(String points, String type, Boolean enter, Map<String, Object> others) {
+            return new Roi(Point.from(points), type, enter, others);
+        }
 
         public static Roi line(List<Point> points, boolean enter, Map<String, Object> others) {
             return new Roi(points, TYPE_LINE, enter, others);
@@ -161,6 +166,42 @@ public class RoiObject implements Externalizable {
 
         public static Point of(float coordinateX, float coordinateY) {
             return new Point(coordinateX, coordinateY);
+        }
+
+        public static List<Point> from(String points) {
+            if (StringUtils.isBlank(points)) {
+                return new ArrayList<>(0);
+            }
+            String[] pointValues = StringUtils.split(points, ';');
+            List<Point> result = new ArrayList<>(pointValues.length);
+            for (String pointValue : pointValues) {
+                String[] coordinates = StringUtils.split(pointValue, ',');
+                if (coordinates.length != 2) {
+                    throw new IllegalArgumentException("Illegal ROI point format: " + pointValue);
+                }
+                result.add(Point.of(
+                    Float.parseFloat(StringUtils.trim(coordinates[0])),
+                    Float.parseFloat(StringUtils.trim(coordinates[1]))
+                ));
+            }
+            return result;
+        }
+
+        public static String to(List<Point> points) {
+            if (CollectionUtils.isEmpty(points)) {
+                return "";
+            }
+            StringBuilder builder = new StringBuilder();
+            for (Point point : points) {
+                if (builder.length() > 0) {
+                    builder.append(';');
+                }
+                builder
+                    .append(point.getCoordinateX())
+                    .append(',')
+                    .append(point.getCoordinateY());
+            }
+            return builder.toString();
         }
 
         @Override

--- a/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ai/cv/data/RoiObject.java
+++ b/jetlinks-sdk-api/src/main/java/org/jetlinks/sdk/server/ai/cv/data/RoiObject.java
@@ -159,10 +159,10 @@ public class RoiObject implements Externalizable {
     public static class Point implements Externalizable {
 
         @Schema(title = "x轴坐标")
-        private float coordinateX;
+        private float x;
 
         @Schema(title = "y轴坐标")
-        private float coordinateY;
+        private float y;
 
         public static Point of(float coordinateX, float coordinateY) {
             return new Point(coordinateX, coordinateY);
@@ -197,23 +197,23 @@ public class RoiObject implements Externalizable {
                     builder.append(';');
                 }
                 builder
-                    .append(point.getCoordinateX())
+                    .append(point.getX())
                     .append(',')
-                    .append(point.getCoordinateY());
+                    .append(point.getY());
             }
             return builder.toString();
         }
 
         @Override
         public void writeExternal(ObjectOutput out) throws IOException {
-            out.writeFloat(coordinateX);
-            out.writeFloat(coordinateY);
+            out.writeFloat(x);
+            out.writeFloat(y);
         }
 
         @Override
         public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-            coordinateX = in.readFloat();
-            coordinateY = in.readFloat();
+            x = in.readFloat();
+            y = in.readFloat();
         }
     }
 }


### PR DESCRIPTION
## 目的

- 为目标检测结果增加 ROI 标注结构，承载 ZLMedia 初判识别结果中 `roi` 数组数据。
- 补充检测对象标注和扩展信息的便捷写入方法。

## 核心变动

- 新增 `RoiObject`，提供 `ANNOTATIONS_KEY = "roi"`、ROI 列表容器和单个 ROI 结构。
- 单个 ROI 支持 `roi`、`type`、`enter`、`others` 字段，并实现 `Externalizable` 序列化。
- `DetectedObject` 新增 `addAnnotation`、`addOther` 方法，便于写入结构化标注和其他扩展信息。
- `ImageData.Type` 和字段标记为 `@Deprecated`。

## 测试结果

- 自动化测试：未运行。
- 单元测试：0 passed, 0 failed, 0 skipped。
- 集成测试：不适用，本次未涉及数据库、消息、事件、协议联调、外部服务或启动装配。
- 覆盖率：未生成覆盖率报告。
- 说明：当前工作区要求 Java 编译验证由用户自行完成；本 PR 先以 draft 提交，等待本地 Maven 编译/测试数据补齐后再转 ready。

## 文档同步情况

- 未新增仓库文档。
- 依据来源为 ZLMedia AI 数据结构说明中的初判识别结果 `type=0` 的 `roi` 字段。

## 风险与说明

- 影响范围：`jetlinks-sdk-api` 的计算机视觉目标检测结果数据结构。
- 公共契约：新增公开数据类和便捷方法，已补类注释和字段 Schema。
- 链路追踪：不适用，纯 SDK 数据结构变更。
- MBean 运维可观测性：不适用，未新增常驻任务、缓存、队列或后台执行器。
- 未覆盖场景：尚未执行 Maven 编译、单元测试和序列化回归测试。
